### PR TITLE
Add deletecollection to role for multinamespace

### DIFF
--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -58,6 +58,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch


### PR DESCRIPTION
## Summary

The multi-namespace role was missing a deletecollection verb for pod resources. [This verb is present for the single namespace role](https://github.com/ray-project/kuberay-helm/blob/bbde24accbfc842201d7c4c7e6d2e7ebb01bb69f/helm-chart/kuberay-operator/templates/role.yaml#L52-L62).

## Testing

- Chart version 1.1.0
- Applied this patch locally and pods were deleted

